### PR TITLE
Add NPM publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: NPM Publish
+
+on:
+  workflow_call:
+    inputs:
+      fetch-depth:
+        description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+        default: 1
+        type: number
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: bloq/actions/publish-to-npm@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,4 +23,5 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
       - uses: bloq/actions/publish-to-npm@v1
         with:
+          provenance: "true"
           token: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Actions and workflows to make GitHub Actions simpler, more robust and more effic
 
 ## Actions
 
-- `setup-node-env`: Setups up Node, restores NPM cache and installs dependencies
-- `publish-to-npm`: Sets up Node, runs the prepublishOnly script and publishes the package to the NPM registry
+- `notify-deploy-to-slack`: Sends a notification to Slack using a pre-configured webhook.
+- `publish-to-npm`: Sets up Node, runs the prepublishOnly script and publishes the package to the NPM registry.
+- `setup-node-env`: Setups up Node, restores NPM cache and installs dependencies.
 
 ## Reusable workflows
 
-- `js-checks`: Run standard checks as linter, code formatter; then run tests against different Node versions
+- `js-checks`: Run standard checks as linter, code formatter; then run tests against different Node versions.
+- `npm-publish`: Publish a package to NPM.
 
 ## Usage
 

--- a/publish-to-npm/action.yml
+++ b/publish-to-npm/action.yml
@@ -17,6 +17,7 @@ runs:
       shell: bash
     - uses: JS-DevTools/npm-publish@v3
       with:
+        provenance: true
         token: ${{ inputs.token }}
 
 branding:

--- a/publish-to-npm/action.yml
+++ b/publish-to-npm/action.yml
@@ -8,6 +8,10 @@ inputs:
   token:
     description: The NPM access token to use when publishing
     required: true
+  provenance:
+    description: Attach provenance statements when publishing
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -17,7 +21,7 @@ runs:
       shell: bash
     - uses: JS-DevTools/npm-publish@v3
       with:
-        provenance: true
+        provenance: ${{ inputs.provenance == "true" }}
         token: ${{ inputs.token }}
 
 branding:


### PR DESCRIPTION
Add a new reusable workflow to publish NPM packages and allow setting the `provenance` on when using the NPM publish action.