### PR TITLE
Remove the erroneous condition

### DIFF
--- a/publish-to-npm/action.yml
+++ b/publish-to-npm/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
     - uses: JS-DevTools/npm-publish@v3
       with:
-        provenance: ${{ inputs.provenance == "true" }}
+        provenance: ${{ inputs.provenance }}
         token: ${{ inputs.token }}
 
 branding:


### PR DESCRIPTION
The provenance input shall be passed as is to JS-DevTools/npm-publish as it will receive it as string and later cast it to boolean.